### PR TITLE
Updating Waffle Link to Be Accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ My favourite setup for writing Solidity smart contracts.
 - [Buidler](https://github.com/nomiclabs/buidler): compile and run the smart contracts on a local development network
 - [TypeChain](https://github.com/ethereum-ts/TypeChain): generate TypeScript types for smart contracts
 - [Ethers](https://github.com/ethers-io/ethers.js/): renowned Ethereum library and wallet implementation
-- [Waffle](https://github.com/Waffle/waffle): tooling for writing comprehensive smart contract tests
+- [Waffle](https://github.com/EthWorks/Waffle): tooling for writing comprehensive smart contract tests
 - [Solhint](https://github.com/protofire/solhint): linter
 - [Solcover](https://github.com/sc-forks/solidity-coverage) code coverage
 - [Prettier Plugin Solidity](https://github.com/prettier-solidity/prettier-plugin-solidity): code formatter


### PR DESCRIPTION
Updating the waffle link to change from Waffle the Windows Authentication Network  to Waffle the Smart Contract Test link intented.